### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,6 +21,12 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+    @category_name = @item.category.name
+  end
+  
+
   private
 
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
     <% if @items.present? %>
       <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to "#items_path(item)" do %>
+          <%= link_to item_path(item) do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
               <%#if item.sold_out? %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,9 +132,6 @@
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
               <%#if item.sold_out? %>
-                <div class='sold-out'>
-                  <span>Sold Out!!</span>
-                </div>
               <%#end %>
             </div>
             <div class='item-info'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,9 +9,6 @@
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
       <%#if item.sold_out? %>
-         <div class="sold-out">
-           <span>Sold Out!!</span>
-        </div>
       <%#end %>
     </div>
     <div class="item-price-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -19,17 +19,17 @@
         <%= @item.shipping_cost.name %>
       </span>
     </div>
-
-   <% if current_user == @item.user %>
+   <% if user_signed_in? %>
+     <% if current_user == @item.user %>
      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
      <p class="or-text">or</p>
      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-   <% else %>
+     <% else %>
      <%# unless @item.sold_out? %>
        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%> 
       <%# end %>
+     <% end %>
    <% end %>
-   
     <div class="item-explain-box">
       <span><%= @item.description %></span>
     </div>
@@ -96,9 +96,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @category_name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,67 +4,63 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.title %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%#if item.sold_out? %>
+         <div class="sold-out">
+           <span>Sold Out!!</span>
+        </div>
+      <%#end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= number_to_currency(@item.price, unit: "", precision: 0, format: "%n") %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_cost.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+   <% if current_user == @item.user %>
+     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+     <p class="or-text">or</p>
+     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+   <% else %>
+     <%# unless @item.sold_out? %>
+       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%> 
+      <%# end %>
+   <% end %>
+   
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @category_name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_duration.name %></td>
         </tr>
       </tbody>
     </table>
@@ -104,7 +100,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @category_name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
#what
商品詳細表示機能の実装
#why
商品詳細表示ページを実装するため

gyazo 
①ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
[https://gyazo.com/51975e197d6d1d2cade53fcbcca34c3c](url)
② ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
[https://gyazo.com/1d45ae6d8d0d96f16658bceaa7b94388](url)
③ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
[https://gyazo.com/0e41d7b523156c04c491da8ee7dd9233](url)
④ログアウト状態で、商品詳細ページへ遷移した動画
[https://gyazo.com/a2427f880315f89bbd27efba02e468be](url)